### PR TITLE
Add missing component for msbuild path

### DIFF
--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -74,14 +74,6 @@ MSBuildTools.prototype.buildProject = function(projFile, buildType, buildarch, o
 
 // returns full path to msbuild tools required to build the project and tools version
 module.exports.findAvailableVersion = function () {
-    if (process.env.VSINSTALLDIR) {
-        try {
-            var msBuildPath = process.env.VSINSTALLDIR + "\\MSBuild\\15.0\\Bin";
-            return Q([getMSBuildToolsAt(msBuildPath)]);
-        } catch (e) {
-        }
-    }
-
     var versions = ['15.0', '14.0', '12.0', '4.0'];
 
     return Q.all(versions.map(checkMSBuildVersion)).then(function (versions) {
@@ -92,7 +84,7 @@ module.exports.findAvailableVersion = function () {
     });
 };
 
-module.exports.findAllAvailableVersions = function () {
+function findAllAvailableVersionsFallBack() {
     var versions = ['15.0', '14.0', '12.0', '4.0'];
     events.emit('verbose', 'Searching for available MSBuild versions...');
 
@@ -101,6 +93,15 @@ module.exports.findAllAvailableVersions = function () {
             return !!item;
         });
     });
+}
+
+module.exports.findAllAvailableVersions = function () {
+    if (process.env.VSINSTALLDIR) {
+        var msBuildPath = process.env.VSINSTALLDIR + "\\MSBuild\\15.0\\Bin";
+        return getMSBuildToolsAt(msBuildPath).then(function (msBuildTools) { return [msBuildTools]; }).catch(findAllAvailableVersionsFallBack);
+    }
+
+    return findAllAvailableVersionsFallBack();
 };
 
 /**

--- a/template/cordova/lib/MSBuildTools.js
+++ b/template/cordova/lib/MSBuildTools.js
@@ -74,6 +74,14 @@ MSBuildTools.prototype.buildProject = function(projFile, buildType, buildarch, o
 
 // returns full path to msbuild tools required to build the project and tools version
 module.exports.findAvailableVersion = function () {
+    if (process.env.VSINSTALLDIR) {
+        try {
+            var msBuildPath = process.env.VSINSTALLDIR + "\\MSBuild\\15.0\\Bin";
+            return Q([getMSBuildToolsAt(msBuildPath)]);
+        } catch (e) {
+        }
+    }
+
     var versions = ['15.0', '14.0', '12.0', '4.0'];
 
     return Q.all(versions.map(checkMSBuildVersion)).then(function (versions) {

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -68,7 +68,7 @@ module.exports.run = function run (buildOptions) {
 
         events.emit('log', 'Found VSINSTALLDIR environment variable. Attempting to build project using that version of MSBuild');
 
-        return MSBuildTools.getMSBuildToolsAt(process.env.VSINSTALLDIR)
+        return MSBuildTools.getMSBuildToolsAt(process.env.VSINSTALLDIR + "\\MSBuild\\15.0\\Bin")
         .then(function (tools) { return [tools]; })
         .catch(function (err) {
             // If we failed to find msbuild at VSINSTALLDIR

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -67,8 +67,15 @@ module.exports.run = function run (buildOptions) {
         }
 
         events.emit('log', 'Found VSINSTALLDIR environment variable. Attempting to build project using that version of MSBuild');
+        var msBuildPath = process.env.VSINSTALLDIR + "\\MSBuild\\15.0\\Bin";
+        fs.statSync(msBuildPath, function(err, stats) {
+            if (err && err.code === 'ENOENT') {
+                events.emit('log', 'Cannot find MSBuild path under VSINSTALLDIR. The following path does not exist: ' + msBuildPath);
+                return MSBuildTools.findAllAvailableVersions();
+            }
+        });
 
-        return MSBuildTools.getMSBuildToolsAt(process.env.VSINSTALLDIR + "\\MSBuild\\15.0\\Bin")
+        return MSBuildTools.getMSBuildToolsAt(msBuildPath)
         .then(function (tools) { return [tools]; })
         .catch(function (err) {
             // If we failed to find msbuild at VSINSTALLDIR

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -59,30 +59,7 @@ module.exports.run = function run (buildOptions) {
 
     var buildConfig = parseAndValidateArgs(buildOptions);
 
-    return Q().then(function () {
-        // CB-11548 use VSINSTALLDIR environment if defined to find MSBuild
-        // If VSINSTALLDIR is not specified use default discovery mechanism
-        if (!process.env.VSINSTALLDIR) {
-            return MSBuildTools.findAllAvailableVersions();
-        }
-
-        events.emit('log', 'Found VSINSTALLDIR environment variable. Attempting to build project using that version of MSBuild');
-        var msBuildPath = process.env.VSINSTALLDIR + "\\MSBuild\\15.0\\Bin";
-        fs.statSync(msBuildPath, function(err, stats) {
-            if (err && err.code === 'ENOENT') {
-                events.emit('log', 'Cannot find MSBuild path under VSINSTALLDIR. The following path does not exist: ' + msBuildPath);
-                return MSBuildTools.findAllAvailableVersions();
-            }
-        });
-
-        return MSBuildTools.getMSBuildToolsAt(msBuildPath)
-        .then(function (tools) { return [tools]; })
-        .catch(function (err) {
-            // If we failed to find msbuild at VSINSTALLDIR
-            // location we fall back to default discovery
-            return MSBuildTools.findAllAvailableVersions();
-        });
-    })
+    return Q().then(MSBuildTools.findAllAvailableVersions)
     .then(function(msbuildTools) {
         // Apply build related configs
         prepare.updateBuildConfig(buildConfig);

--- a/template/cordova/lib/build.js
+++ b/template/cordova/lib/build.js
@@ -60,18 +60,18 @@ module.exports.run = function run (buildOptions) {
     var buildConfig = parseAndValidateArgs(buildOptions);
 
     return Q().then(function () {
-        // CB-11548 use LOCALMSBUILDBINPATH environment if defined to find MSBuild
-        // If LOCALMSBUILDBINPATH is not specified use default discovery mechanism
-        if (!process.env.LOCALMSBUILDBINPATH) {
+        // CB-11548 use VSINSTALLDIR environment if defined to find MSBuild
+        // If VSINSTALLDIR is not specified use default discovery mechanism
+        if (!process.env.VSINSTALLDIR) {
             return MSBuildTools.findAllAvailableVersions();
         }
 
-        events.emit('log', 'Found LOCALMSBUILDBINPATH environment variable. Attempting to build project using that version of MSBuild');
+        events.emit('log', 'Found VSINSTALLDIR environment variable. Attempting to build project using that version of MSBuild');
 
-        return MSBuildTools.getMSBuildToolsAt(process.env.LOCALMSBUILDBINPATH)
+        return MSBuildTools.getMSBuildToolsAt(process.env.VSINSTALLDIR)
         .then(function (tools) { return [tools]; })
         .catch(function (err) {
-            // If we failed to find msbuild at LOCALMSBUILDBINPATH
+            // If we failed to find msbuild at VSINSTALLDIR
             // location we fall back to default discovery
             return MSBuildTools.findAllAvailableVersions();
         });


### PR DESCRIPTION
Add missing component for msbuild path.
Revert the name change since that variable will not be available in VS command prompt.
